### PR TITLE
cleanup hbmk2 build system, add support for Windows MSYS2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,21 @@
 #!/bin/sh -e
 
-# hbmk2 must be in PATH
+if ! which hbmk2 > /dev/null; then
+   echo '! Error: hbmk2 missing from PATH'
+   exit 1
+fi
 
-# Windows - MSYS2 packages required:
-#    pacman -S mingw-w64-{i686,x86_64}-{gtk2,gobject-introspection}
+if ! pkg-config glib-2.0 || \
+   ! pkg-config gobject-introspection-1.0; then
+   echo '! Error: Required components missing: glib, gobject-introspection'
+   case "$(uname)" in
+      *_NT*)
+      echo '! Install using:'
+      echo '  pacman -S mingw-w64-{i686,x86_64}-{gtk2,glib,gobject-introspection}'
+      ;;
+   esac
+   exit 1
+fi
 
 # static
 hbmk2 gihb.hbp

--- a/build.sh
+++ b/build.sh
@@ -1,63 +1,16 @@
-#!/bin/sh
+#!/bin/sh -e
 
-HARBOUR_HOME="$HOME/build/harbour-git"
-HARBOUR_PLAT="darwin/gcc"
-HBMK2="$HARBOUR_HOME/bin/$HARBOUR_PLAT/hbmk2 -q0 -w2 -es2 -debug -optim- -cflag=-Wno-missing-field-initializers"
+# hbmk2 must be in PATH
 
-# If HBGI_DYN is set to "no", build everything statically; helps debugging
-HBGI_DYN="no"
+# Windows - MSYS2 packages required:
+#    pacman -S mingw-w64-{i686,x86_64}-{gtk2,gobject-introspection}
 
-HBGIHB_SOURCES="
-        hbgihb.c
-        "
+# static
+hbmk2 gihb.hbp
+hbmk2 gobject.hbp
+hbmk2 gi.hbp
+hbmk2 test.prg -otest_s -gtcgi hbgi.hbc
 
-HBGOBJECT_SOURCES="
-        hbgobject.c
-        hbginterface.c
-        hbgpointer.c
-        hbgtype.c
-        "
-
-HBGI_SOURCES="
-        hbgicore.c
-        hbgi-argument.c
-        hbgi-boxed.c
-        hbgi-callbacks.c
-        hbgi-closure.c
-        hbgi-info.c
-        hbgi-invoke.c
-        hbgi-signal-closure.c
-        hbgi-struct-marshal.c
-        hbgi-type.c
-        "
-
-HBGOBJECT_FLAGS="$(pkg-config --cflags --libs glib-2.0)"
-HBGI_FLAGS="$(pkg-config --cflags --libs gobject-introspection-1.0)"
-
-for F in $HBGIHB_SOURCES; do HBGIHB_SOURCES_PREFIXED="$HBGIHB_SOURCES_PREFIXED hb/$F"; done
-for F in $HBGOBJECT_SOURCES; do HBGOBJECT_SOURCES_PREFIXED="$HBGOBJECT_SOURCES_PREFIXED gobject/$F"; done
-for F in $HBGI_SOURCES; do HBGI_SOURCES_PREFIXED="$HBGI_SOURCES_PREFIXED gi/$F"; done
-
-if [ $HBGI_DYN == "no" ]; then
-
-cd hb
-$HBMK2 -hblib -o../hbgihb $HBGIHB_SOURCES || exit $?
-
-cd ../gobject
-$HBMK2 -hblib -o../hbgobject -I../hb -I../gi $HBGOBJECT_FLAGS $HBGOBJECT_SOURCES || exit $?
-
-cd ../gi
-$HBMK2 -hblib -o../hbgi -I../hb -I../gobject -I../gi $HBGI_FLAGS $HBGI_SOURCES || exit $?
-
-cd ..
-
-$HBMK2 -L. -lhbgihb -lhbgobject -lhbgi -gtcgi $HBGI_FLAGS test.prg || exit $?
-
-else
-
-$HBMK2 -hbdyn -ohbgi -g $HBGIHB_SOURCES_PREFIXED $HBGOBJECT_SOURCES_PREFIXED $HBGI_SOURCES_PREFIXED -Ihb -Igobject -Igi $HBGOBJECT_FLAGS $HBGI_FLAGS || exit $?
-
-#$HBMK2 -L. -lhbgi -gtcgi test.prg || exit $?
-$HBMK2 -L. -lhbgi -L$HARBOUR_HOME/lib/$HARBOUR_PLAT -gtcgi test.prg || exit $?
-
-fi
+# dynamic
+hbmk2 -hbdyn -shared '{win}-lhbmaindllp' @gi.hbp @gobject.hbp @gihb.hbp -ohbgidyn
+hbmk2 test.prg -otest_d -gtcgi -env:HBGI_DYNAMIC=yes hbgi.hbc

--- a/gi.hbp
+++ b/gi.hbp
@@ -1,0 +1,13 @@
+-hblib
+-ohbgi
+
+-Ihb
+-Igi
+-Igobject
+
+gi/gi.hbm
+
+"-cflag=`pkg-config --cflags gobject-introspection-1.0`"
+
+hbgi.hbm
+hbgi.hbc

--- a/gi/gi.hbm
+++ b/gi/gi.hbm
@@ -1,0 +1,10 @@
+hbgicore.c
+hbgi-argument.c
+hbgi-boxed.c
+hbgi-callbacks.c
+hbgi-closure.c
+hbgi-info.c
+hbgi-invoke.c
+hbgi-signal-closure.c
+hbgi-struct-marshal.c
+hbgi-type.c

--- a/gihb.hbp
+++ b/gihb.hbp
@@ -1,0 +1,7 @@
+-hblib
+-ohbgihb
+
+hb/gihb.hbm
+
+hbgi.hbm
+hbgi.hbc

--- a/gobject.hbp
+++ b/gobject.hbp
@@ -1,0 +1,12 @@
+-hblib
+-ohbgobject
+
+-Ihb
+-Igi
+
+gobject/gobject.hbm
+
+"-cflag=`pkg-config --cflags glib-2.0`"
+
+hbgi.hbm
+hbgi.hbc

--- a/gobject/gobject.hbm
+++ b/gobject/gobject.hbm
@@ -1,0 +1,4 @@
+hbgobject.c
+hbginterface.c
+hbgpointer.c
+hbgtype.c

--- a/hb/gihb.hbm
+++ b/hb/gihb.hbm
@@ -1,0 +1,1 @@
+hbgihb.c

--- a/hbgi.hbc
+++ b/hbgi.hbc
@@ -1,0 +1,10 @@
+# directives to link hbgi to an app
+
+libpaths=.
+libs=hbgihb hbgobject hbgi{!HBGI_DYNAMIC}
+libs=hbgidyn{HBGI_DYNAMIC}
+
+ldflags+="`pkg-config --libs glib-2.0`"
+ldflags+="`pkg-config --libs gobject-introspection-1.0`"
+dflags+="`pkg-config --libs glib-2.0`"
+dflags+="`pkg-config --libs gobject-introspection-1.0`"

--- a/hbgi.hbm
+++ b/hbgi.hbm
@@ -1,0 +1,6 @@
+# common compiler options for building hbgi itself
+
+-q0 -w2 -es2
+-debug
+-optim-
+-cflag=-Wno-missing-field-initializers


### PR DESCRIPTION
The `gi` and `gobject` sources use an internal Harbour API, causing the `.dll` to fail to link, which is expected. The internal API should be replaced with a public alternative to fix this.

On my system, the static, 64-bit test.exe crashes after some point.

Another note: `.hbm` files are not mandatory. They can be integrated into their only referrer, the `.hbp` files in the root (after adding the relative paths to the contained source filenames). Or the file list can be replaced by a wildcard: `*.c` (in `.hbm`) or `gobject/*.c` (in `.hbp`).

[Recreated https://github.com/tuffnatty/hbgi/pull/7 after fixing a very minor typo in a comment]